### PR TITLE
Fix link to GitHub page.

### DIFF
--- a/_posts/2015-07-21-contact.md
+++ b/_posts/2015-07-21-contact.md
@@ -22,7 +22,7 @@ Chennai -- 600 036<br/><br/>
 <i class="fa fa-link fa-2x"></i><br/><a href="https://home.iitm.ac.in/kraman/lab/">Lab Website @ IIT Madras</a><br/><br/>
 
 
-<a href="http://github.com/in/karthikraman"><i class="fa fa-github fa-3x"></i></a>
+<a href="http://github.com/karthikraman"><i class="fa fa-github fa-3x"></i></a>
 &nbsp;&nbsp;&nbsp;
 <a href="http://linkedin.com/in/ramankarthik"><i class="fa fa-linkedin-square fa-3x"></i></a>
 &nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
The link to your GitHub page had an "in/" in it - presumably from editing the LinkedIn link - and so was broken.
